### PR TITLE
Removes other warning while deploying in Vite

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ const plugin = (userOptions) => {
                 }
 
                 return {
-                    code
+                    code,
+                    map: null
                 }
             }
 


### PR DESCRIPTION
That warning appears when the plugin returns undefined map code. It's better return null for map.

Related to issue #2 