### PR TITLE
Resolve globs before using them into sync function

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,20 @@ const plugin = (userOptions) => {
         return content
     }
 
+    const resolvePaths = (files, rootPath) => {
+        const resolvedFiles = {...files}
+        Object.keys(files).forEach(input => {
+            resolvedFiles[input] = files[input].map(entry => resolve(rootPath, entry))
+        })
+        return resolvedFiles
+    }
+
     return {
         name: '@vituum/vite-plugin-concat',
         enforce: 'pre',
         configResolved (config) {
             resolvedConfig = config
+            options.files = resolvePaths(options.files, resolvedConfig.root)
         },
         transform (code, path) {
             if (options.input.find(input => path.split('?')[0].endsWith(input))) {
@@ -42,8 +51,7 @@ const plugin = (userOptions) => {
 
                 if (filesInput) {
                     FastGlob.sync(options.files[filesInput]).forEach(entry => {
-                        const path = resolve(resolvedConfig.root, entry)
-                        const file = fs.readFileSync(path).toString()
+                        const file = fs.readFileSync(entry).toString()
 
                         code = code + '\n' + file
                     })

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ const plugin = (userOptions) => {
                 }
 
                 return {
-                    code
+                    code,
+                    map: null
                 }
             }
 


### PR DESCRIPTION
Resolving the globs for the entries with the root directory of the config seems to resolve the issue #5 .

I've created a function to resolve all the globs in the plugin config called `resolvePaths`. Then I've used it when Vite pass the config to the plugin to resolve all the globs.